### PR TITLE
Use var for node exporter port

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ node_exporter_download_url: https://github.com/prometheus/node_exporter/releases
 node_exporter_bin_path: /usr/local/bin/node_exporter
 
 node_exporter_options: ''
+node_exporter_port: '9100'
 
 node_exporter_state: started
 node_exporter_enabled: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,7 +50,7 @@
 
 - name: Verify node_exporter is responding to requests.
   uri:
-    url: http://localhost:9100/
+    url: http://localhost:{{ node_exporter_port }}/
     return_content: true
   register: metrics_output
   failed_when: "'Metrics' not in metrics_output.content"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,7 +50,7 @@
 
 - name: Verify node_exporter is responding to requests.
   uri:
-    url: http://localhost:{{ node_exporter_port }}/
+    url: "http://localhost:{{ node_exporter_port }}/"
     return_content: true
   register: metrics_output
   failed_when: "'Metrics' not in metrics_output.content"


### PR DESCRIPTION
Using `node_exporter_options` we can set whatever port we like for Prometheus but the task `Verify node_exporter is responding to requests` has hardcoded port. Setting this as a variable with default set to `9100` allows us to set the port to another number and will not impact any builds currently depending on this. Port 9100 can conflict with other middleware installed (e.g. websphere 9.X)  

resolves #5 
