### PR TITLE
Do not move when not downloaded

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,7 @@
   when: >
     node_exporter_version_check.stdout is not defined
     or node_exporter_version not in node_exporter_version_check.stdout
+  register: node_exporter_download_check
 
 - name: Move node_exporter binary into place.
   copy:
@@ -22,6 +23,7 @@
     mode: 0755
     remote_src: true
   notify: restart node_exporter
+  when: node_exporter_download_check.stdout is defined
 
 - name: Create node_exporter user.
   user:


### PR DESCRIPTION
Binary should not be moved when not downloaded.

Got some errors when /tmp/ file was deleted by other processes when running the playbook for a second time.