### PR TITLE
Added variables for host and port

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ The architecture and download URL for Node exporter. If you're on a Raspberry Pi
 
 The path where the `node_exporter` binary will be installed.
 
+    node_exporter_host: 'localhost'
+    node_exporter_port: 9100
+
+Host and port on which node exporter will listen.
+
     node_exporter_options: ''
 
 Any additional options to pass to `node_exporter` when it starts, e.g. `--no-collector.wifi` if you want to ignore any WiFi data.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,8 @@ node_exporter_download_url: https://github.com/prometheus/node_exporter/releases
 
 node_exporter_bin_path: /usr/local/bin/node_exporter
 
+node_exporter_host: "localhost"
+node_exporter_port: 9100
 node_exporter_options: ''
 
 node_exporter_state: started

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,7 +52,7 @@
 
 - name: Verify node_exporter is responding to requests.
   uri:
-    url: http://localhost:9100/
+    url: "http://{{ node_exporter_host }}:{{ node_exporter_port }}/"
     return_content: true
   register: metrics_output
   failed_when: "'Metrics' not in metrics_output.content"

--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -4,7 +4,7 @@ Description=NodeExporter
 [Service]
 TimeoutStartSec=0
 User=node_exporter
-ExecStart={{ node_exporter_bin_path }} {{ node_exporter_options }}
+ExecStart={{ node_exporter_bin_path }} --web.listen-address={{ node_exporter_host }}:{{ node_exporter_port }} {{ node_exporter_options }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
For security reasons, I would like to start node_exporter only on VPN IP address. I've tried to add -`-web.listen-address=XX.XX.XX.XX:9100` to `node_exporter_options`, but role fails as it tries to verify URL `http://localhost:9100/` in the last task. So I've added two variables `node_exporter_host` and  `node_exporter_port` that user can specify explicitly.