### PR TITLE
Added variable to use when node_exporter_host and url to check differs

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,7 +52,7 @@
 
 - name: Verify node_exporter is responding to requests.
   uri:
-    url: "http://{{ node_exporter_host }}:{{ node_exporter_port }}/"
+    url: "http://{{ node_exporter_host_for_check | default(node_exporter_host) }}:{{ node_exporter_port }}/"
     return_content: true
   register: metrics_output
   failed_when: "'Metrics' not in metrics_output.content"


### PR DESCRIPTION
The approach introduced through #15 leads to a problem if one is exposing `node_exporter` to `0.0.0.0` in a controlled environment, protected with firewalls, in my humble opinion. The problem is that `0.0.0.0` is a valid address for a service to bind to, but not usable for the `uri` module to check if `node_exporter` is up and running. Therefore one should be able to specify the host for the availability check.