### PR TITLE
Do not set listen address to localhost by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,8 @@ node_exporter_download_url: https://github.com/prometheus/node_exporter/releases
 
 node_exporter_bin_path: /usr/local/bin/node_exporter
 
-node_exporter_host: "localhost"
+# Set node_exporter_host to locahost if you wish to expose node_exporter on localhost only.
+node_exporter_host: ''
 node_exporter_port: 9100
 node_exporter_options: ''
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,7 +52,7 @@
 
 - name: Verify node_exporter is responding to requests.
   uri:
-    url: "http://{{ node_exporter_host }}:{{ node_exporter_port }}/"
+    url: "http://{% if node_exporter_host !='' %}{{ node_exporter_host }}{% else %}localhost{% endif %}:{{ node_exporter_port }}/"
     return_content: true
   register: metrics_output
   failed_when: "'Metrics' not in metrics_output.content"


### PR DESCRIPTION
Pull Reuqest #15 added some new functionality where one can limit on which interfaces `node_exporter` can listen to. PR adds a couple of variables to configure node_exporter accordingly (`node_exporter_host` and `node_exporter_port`).
By default, node_exporter listens on all interfaces (unless explicity specify a listen address with `--web.listen_address` flag). 
`node_exporter_host` is currently set to `localhost` (default value), which means that node_exporter would listen only to lcahost. This is not an expected behavior (Prometheus who would scrape metrics is not on the same host). Thus many playbooks would end up altering node_exporter config to an undesired state and lead to hosts not being scraped properly.

This commit addresses the issue and retains backwards compatibility.
`node_exporter_host` default value is empty. Anyone wishing to limit where `node_exporter` listens to, can always override this variable.
As for the verification tasks, a Jinja inline if is used. It's not very elegant, but does the job!
Even in cases where `node_exporter_host` is set, verify step can work (as it would depend of firewall settings).