### PR TITLE
Fix idempotency on rare conditions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,9 @@
     mode: 0755
     remote_src: true
   notify: restart node_exporter
-  when: node_exporter_download_check is changed
+  when: >
+    node_exporter_download_check is changed
+    or node_exporter_version_check.stdout | length == 0
 
 - name: Create node_exporter user.
   user:


### PR DESCRIPTION
This patch fixes the rare case when the playbook has been executed and the node_exporter binary gets deleted from `node_exporter_bin_path` but it's still present on `/tmp/node_exporter`. The condition "node_exporter_download_check is changed" will be false but the binary is not on its final location.

Steps to reproduce:

- Execute the playbook
- Remove /usr/local/bin/node_exporter
- Execute the paybook again

I'm using `node_exporter_version_check.stdout | length == 0` because of [this tip](https://stackoverflow.com/a/59085721/1279003).
