### PR TITLE
Enable "latest" for the node_exporter_version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@
 name: CI
 'on':
   pull_request:
-  workflow_dispatch:
   push:
     branches:
       - master

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# Use the latest node_exporter release
+## Use the latest node_exporter release
 node_exporter_version: 'latest'
 
 ## Alternatively, set a specific version

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,12 +1,17 @@
 ---
-# See available releases: https://github.com/prometheus/node_exporter/releases/
-node_exporter_version: '0.18.1'
+# Use the latest node_exporter release
+node_exporter_version: 'latest'
+
+## Alternatively, set a specific version
+## See available releases: https://github.com/prometheus/node_exporter/releases/
+# node_exporter_version: '0.18.1' 
+
 node_exporter_arch: 'amd64'
 node_exporter_download_url: https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ node_exporter_arch }}.tar.gz
 
 node_exporter_bin_path: /usr/local/bin/node_exporter
 
-# Set node_exporter_host to locahost if you wish to expose node_exporter on localhost only.
+## Set node_exporter_host to localhost if you wish to expose node_exporter on localhost only.
 node_exporter_host: ''
 node_exporter_port: 9100
 node_exporter_options: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
-## Use the latest node_exporter release
+# Use the latest node_exporter release
 node_exporter_version: 'latest'
 
-## Alternatively, set a specific version
-## See available releases: https://github.com/prometheus/node_exporter/releases/
+# Alternatively, set a specific version
+# See available releases: https://github.com/prometheus/node_exporter/releases/
 # node_exporter_version: '0.18.1'
 
 node_exporter_arch: 'amd64'
@@ -11,7 +11,7 @@ node_exporter_download_url: https://github.com/prometheus/node_exporter/releases
 
 node_exporter_bin_path: /usr/local/bin/node_exporter
 
-## Set node_exporter_host to localhost if you wish to expose node_exporter on localhost only.
+# Set node_exporter_host to localhost if you wish to expose node_exporter on localhost only.
 node_exporter_host: ''
 node_exporter_port: 9100
 node_exporter_options: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ node_exporter_version: 'latest'
 
 ## Alternatively, set a specific version
 ## See available releases: https://github.com/prometheus/node_exporter/releases/
-# node_exporter_version: '0.18.1' 
+# node_exporter_version: '0.18.1'
 
 node_exporter_arch: 'amd64'
 node_exporter_download_url: https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ node_exporter_arch }}.tar.gz

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,7 +6,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-rockylinux8}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/tasks/config-version.yaml
+++ b/tasks/config-version.yaml
@@ -1,0 +1,19 @@
+---
+- name: Determine latest GitHub release (local)
+  delegate_to: localhost
+  become: false
+  uri:
+    url: "https://api.github.com/repos/prometheus/node_exporter/releases/latest"
+    body_format: json
+  register: _github_release
+  until: _github_release.status == 200
+  retries: 5
+
+- name: Set node_exporter_version
+  set_fact:
+    node_exporter_version: "{{ _github_release.json.tag_name
+      | regex_replace('^v?([0-9\\.]+)$', '\\1') }}"
+
+- name: Set node_exporter_download_url
+  set_fact:
+    node_exporter_download_url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ node_exporter_arch }}.tar.gz"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,12 @@
   changed_when: false
   register: node_exporter_version_check
 
+- name: Configure latest version
+  include_tasks: config-version.yaml
+  when: >
+    node_exporter_version is match("latest")
+    or node_exporter_version is not defined
+
 - name: Download and unarchive node_exporter into temporary location.
   unarchive:
     src: "{{ node_exporter_download_url }}"


### PR DESCRIPTION
This PR add functionality to get the latest version of the node_exporter, and also sets the default value of the role to "latest".

If the latest isn't desired, the version can still be specified in the standard manner. 