### PR TITLE
fix: create node_exporter user as a system user

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,7 @@
   user:
     name: node_exporter
     shell: /sbin/nologin
+    system: true
     state: present
 
 - name: Copy the node_exporter systemd unit file.


### PR DESCRIPTION
Since node_exporter is not a "real" user it should have the system flag set so that the user does not get a uid > 1000.