### PR TITLE
Add configuration option to start service only after a specific service

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,3 +18,8 @@ node_exporter_options: ''
 
 node_exporter_state: started
 node_exporter_enabled: true
+
+# Configure node_exporter.service to start after a specific systemd service
+# If you need node exporter to start after vpn.service
+# node_exporter_start_after: vpn.service
+node_exporter_start_after: ''

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,7 @@
   user:
     name: node_exporter
     shell: /sbin/nologin
+    system: true
     state: present
 
 - name: Copy the node_exporter systemd unit file.

--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -1,5 +1,6 @@
 [Unit]
 Description=NodeExporter
+After={{ node_exporter_start_after }}
 
 [Service]
 TimeoutStartSec=0


### PR DESCRIPTION
Add configuration option to make node exporter systemd service to start after a specific service
This adds a new configuration variable `node_exporter_start_after` in `defaults/main.yml`.

This is useful when node exporter is accessible only through a VPN, which is needed to be started before node exporter can bind to the VPN IP address. 