### PR TITLE
Added privilege escalation to tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,12 +32,14 @@
   when: >
     node_exporter_download_check is changed
     or node_exporter_version_check.stdout | length == 0
+  become: true
 
 - name: Create node_exporter user.
   user:
     name: node_exporter
     shell: /sbin/nologin
     state: present
+  become: true
 
 - name: Copy the node_exporter systemd unit file.
   template:
@@ -45,18 +47,21 @@
     dest: /etc/systemd/system/node_exporter.service
     mode: 0644
   register: node_exporter_service
+  become: true
 
 - name: Reload systemd daemon if unit file is changed.
   systemd:
     daemon_reload: true
   notify: restart node_exporter
   when: node_exporter_service is changed
+  become: true
 
 - name: Ensure node_exporter is running and enabled at boot.
   service:
     name: node_exporter
     state: "{{ node_exporter_state }}"
     enabled: "{{ node_exporter_enabled }}"
+  become: true
 
 - name: Verify node_exporter is responding to requests.
   uri:


### PR DESCRIPTION
Some task require root privileges, like:
- Copying file to /usr/local/bin
- Creating a user
- Creating a systemd unit file
- Starting/configuring the systemd service

Without these, I'm getting "Destination /usr/local/bin not writable" and other errors.