### PR TITLE
Set restart policy for systemd unit

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,3 +18,4 @@ node_exporter_options: ''
 
 node_exporter_state: started
 node_exporter_enabled: true
+node_exporter_restart: on-failure

--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -5,6 +5,7 @@ Description=NodeExporter
 TimeoutStartSec=0
 User=node_exporter
 ExecStart={{ node_exporter_bin_path }} --web.listen-address={{ node_exporter_host }}:{{ node_exporter_port }} {{ node_exporter_options }}
+Restart={{ node_exporter_restart }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Currently, no restart policy is set. This means, when node_exporter is killed for some reason, it will not restart. Setting Restart=on-failure mitigates this problem. This behaviour is configurable via a variable, default is set to on-failure.

The same policy is set in the official debian package: https://salsa.debian.org/go-team/packages/prometheus-node-exporter/-/blob/debian/sid/debian/service#L6