### PR TITLE
Added possibility to set proxy env for delegated localhost task

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you change the version, the `node_exporter` binary will be replaced with the 
     node_exporter_arch: 'amd64'
     node_exporter_download_url: https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ node_exporter_arch }}.tar.gz
 
-As part of the installation, a task querying github is executed on the local machine running ansible. If a proxy is required to access the internet, you can configure it using the `node_exporter_installation_proxy_env_localhost` variable, i.e.:
+As part of the installation, a task querying github is executed on the local machine which runs ansible. If a proxy is required to access the internet, you can configure it using the `node_exporter_installation_proxy_env_localhost` variable, i.e.:
 
     node_exporter_installation_proxy_env_localhost:
       http_proxy: http://proxy:port

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ If you change the version, the `node_exporter` binary will be replaced with the 
     node_exporter_arch: 'amd64'
     node_exporter_download_url: https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-{{ node_exporter_arch }}.tar.gz
 
+As part of the installation, a task querying github is executed on the local machine running ansible. If a proxy is required to access the internet, you can configure it using the `node_exporter_installation_proxy_env_localhost` variable, i.e.:
+
+    node_exporter_installation_proxy_env_localhost:
+      http_proxy: http://proxy:port
+      https_proxy: http://proxy:port
+
 The architecture and download URL for Node exporter. If you're on a Raspberry Pi running Raspbian, you may need to override the `arch` value with `armv7`.
 
     node_exporter_bin_path: /usr/local/bin/node_exporter

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,7 @@ node_exporter_enabled: true
 node_exporter_restart: on-failure
 
 # Set proxy settings for delegated localhost task if required
-node_exporter_installation_proxy_env_localhost: {}=======
+node_exporter_installation_proxy_env_localhost: {}
 # Optionally set the uid/gid for the node_exporter user
 # node_exporter_uid: 1001
 # node_exporter_gid: 1001

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,3 +19,6 @@ node_exporter_options: ''
 node_exporter_state: started
 node_exporter_enabled: true
 node_exporter_restart: on-failure
+
+# Set proxy settings for delegated localhost task if required
+node_exporter_installation_proxy_env_localhost: {}

--- a/tasks/config-version.yaml
+++ b/tasks/config-version.yaml
@@ -9,6 +9,7 @@
   until: _github_release.status == 200
   run_once: true
   retries: 5
+  environment: "{{ node_exporter_installation_proxy_env_localhost }}"
 
 - name: Set node_exporter_version
   set_fact:


### PR DESCRIPTION
Hello @geerlingguy 

At our institution, the system executing Ansible requires proxy configuration to access the internet. However, not all target hosts share this requirement—some can connect directly without proxy settings. Therefore, we need the ability to apply proxy settings exclusively to tasks executed on the Ansible control node.

This pull request introduces a new optional variable, `node_exporter_installation_proxy_env_localhost`, which is passed to tasks delegated to localhost. This ensures that version retrieval function correctly in environments where the control node requires a proxy, but the target nodes do not.