### PR TITLE
Restart systemd service if parameters changed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,11 +46,11 @@
     dest: /etc/systemd/system/node_exporter.service
     mode: 0644
   register: node_exporter_service
+  notify: restart node_exporter
 
 - name: Reload systemd daemon if unit file is changed.
   systemd:
     daemon_reload: true
-  notify: restart node_exporter
   when: node_exporter_service is changed
 
 - name: Ensure node_exporter is running and enabled at boot.


### PR DESCRIPTION
Currently, due to https://github.com/ansible/ansible/issues/77606, the handlers on a "daemon-reload" systemd action are never called.
Thus, when the unit file has been edited after changing some parameters, the service is not restarted unless we do it manually (https://github.com/geerlingguy/ansible-role-node_exporter/issues/33).
This PR fixes it by moving the handler from the "daemon-reload" task to the "template unit file" task, which in effect should be the same (we expect daemon-reload to report a "changed" status when the unit file has changed).