### PR TITLE
Add system flag to node_exporter user creation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,6 +47,7 @@
     create_home: false
     uid: "{{ node_exporter_uid | default(omit) }}"
     group: "{{ (node_exporter_gid is defined) | ternary('node_exporter', omit) }}"
+    system: true
     state: present
 
 - name: Copy the node_exporter systemd unit file.


### PR DESCRIPTION
Set the system flag for user creation, so the user and group default to a system id (e.g. < 1000). This will avoid the need to set a manual override in many cases.
